### PR TITLE
Fix a couple typos

### DIFF
--- a/src/com/taiter/ce/CEListener.java
+++ b/src/com/taiter/ce/CEListener.java
@@ -139,7 +139,7 @@ public class CEListener implements Listener {
             HumanEntity p = event.getPlayer();
             Location loc = p.getLocation().add(0, 1.25, 0);
             Vector velocity = loc.getDirection().multiply(0.25);
-            if (contents[0] != null && !contents[1].getType().equals(Material.AIR))
+            if (contents[0] != null && !contents[0].getType().equals(Material.AIR))
                 if (p.getInventory().firstEmpty() == -1)
                     p.getWorld().dropItem(loc, contents[0]).setVelocity(velocity);
                 else

--- a/src/com/taiter/ce/CEventHandler.java
+++ b/src/com/taiter/ce/CEventHandler.java
@@ -124,7 +124,7 @@ public class CEventHandler {
             CEnchantment ce = list.get(Tools.random.nextInt(list.size()));
             int level = Tools.random.nextInt(ce.getEnchantmentMaxLevel()) + 1;
             ItemStack book = EnchantManager.getEnchantBook(ce, level);
-            e.getInventory().remove(0);
+            e.getInventory().clear(0);
             e.getInventory().setItem(0, book);
             if (!p.getGameMode().equals(GameMode.CREATIVE))
                 p.setLevel(p.getLevel() - 30);


### PR DESCRIPTION
Fixes a couple of typos.

In CEListener: If there is no item in the bottom rune casting slot, a NPE occurs and the item in the top slot is destroyed.

In CEventHandler: The remove function removes an item by item id, while clear removes an item by slot id. It was previously removing all air from the inventory.