### PR TITLE
Only cancel tasks belonging to this plugin instead of canceling all tasks

### DIFF
--- a/src/com/taiter/ce/Main.java
+++ b/src/com/taiter/ce/Main.java
@@ -218,7 +218,7 @@ public final class Main extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        getServer().getScheduler().cancelAllTasks();
+        getServer().getScheduler().cancelTasks(plugin);
         for (CEnchantment c : EnchantManager.getEnchantments())
             if (c instanceof IceAspect)
                 for (HashMap<org.bukkit.block.Block, String> list : ((IceAspect) c).IceLists)


### PR DESCRIPTION
I was wondering why many plugins suddenly stopped working when I disabled Custom Enchantments due to the PlayerMoveEvent NPE...